### PR TITLE
Improve line parsing for golangci lint

### DIFF
--- a/lib/pronto/golang/tools/base.rb
+++ b/lib/pronto/golang/tools/base.rb
@@ -49,7 +49,20 @@ module Pronto
       end
 
       def parse_line(line)
-        file_path, line_number, _, message = line.split(':', 4)
+        elements = line.split(':')
+        file_path   = elements[0]
+        line_number = elements[1]
+
+        case elements.count
+        when 3
+          message = elements[-1]
+        else
+          if elements[2].strip =~ /^\d+$/
+            message = elements[3..].join(':')
+          else
+            message = elements[2..].join(':')
+          end
+        end
 
         dir = directory('')
         if dir != ''

--- a/lib/pronto/golang/tools/govet.rb
+++ b/lib/pronto/golang/tools/govet.rb
@@ -8,18 +8,6 @@ module Pronto
       def available?
         enabled?
       end
-
-      def parse_line(line)
-        # Support handling messages like
-        # - spec/fixtures/test.git/main.go:18:2: unreachable code
-        # - spec/fixtures/test.git/main.go:18: something else
-        elements = line.split(':')
-        file_path   = elements[0]
-        line_number = elements[1]
-        message     = elements[-1]
-
-        return file_path, line_number, :warning, message.to_s.strip
-      end
     end
   end
 end

--- a/lib/pronto/golang/version.rb
+++ b/lib/pronto/golang/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module GolangVersion
-    VERSION = '0.0.14'.freeze
+    VERSION = '0.0.15'.freeze
   end
 end

--- a/spec/pronto/golang/tools/base_spec.rb
+++ b/spec/pronto/golang/tools/base_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Pronto
+  module GolangTools
+
+    describe Base do
+      let(:config) do
+        {}
+      end
+
+      let(:base) do
+        described_class.new(config)
+      end
+
+      describe '#directory' do
+        context 'when nothing is configured' do
+          context 'without parameter' do
+            it "returns '.'" do
+              expect(base.directory).to eq('.')
+            end
+          end
+
+          context 'with parameter' do
+            it 'returns an empty string' do
+              expect(base.directory('')).to eq('')
+            end
+          end
+        end
+
+        context 'when execution_directory is configured' do
+          let(:config) do
+            {
+              'execution_directory' => '/tmp',
+            }
+          end
+
+          context 'without parameter' do
+            it 'returns the configured value' do
+              expect(base.directory).to eq('/tmp')
+            end
+          end
+
+          context 'with parameter' do
+            it 'returns the configured value' do
+              expect(base.directory('')).to eq('/tmp')
+            end
+          end
+        end
+      end
+
+      describe '#parameters' do
+        context 'without parameters configured' do
+          it 'returns an empty string' do
+            expect(base.parameters).to eq('')
+          end
+        end
+
+        context 'with parameters configured' do
+          let(:config) do
+            {
+              'parameters' => 'run',
+            }
+          end
+
+          it 'returns the configured value' do
+            expect(base.parameters).to eq('run')
+          end
+        end
+      end
+
+      describe '#enabled?' do
+        context 'without parameters configured' do
+          it 'returns true by default' do
+            expect(base.enabled?).to eq(true)
+          end
+        end
+
+        context 'with enabled configured' do
+          let(:config) do
+            {
+              'enabled' => false,
+            }
+          end
+
+          it 'returns the configured value' do
+            expect(base.enabled?).to eq(false)
+          end
+        end
+      end
+
+      describe '#execution_mode' do
+        it 'defaults to file' do
+          expect(base.execution_mode).to eq('file')
+        end
+      end
+
+      describe '#parse_line' do
+        [
+          {
+            line:   'spec/fixtures/test.git/main.go:18:2: unreachable code',
+            values: ['spec/fixtures/test.git/main.go', '18', :warning, 'unreachable code'],
+          },
+          {
+            line:   'spec/fixtures/test.git/main.go:18: something else',
+            values: ['spec/fixtures/test.git/main.go', '18', :warning, 'something else'],
+          },
+          {
+            line:   'main.go:21:40: Comment should end in a period (godot)',
+            values: ['main.go', '21', :warning, 'Comment should end in a period (godot)'],
+          },
+          {
+            line:   'long/line.go:21: line is 121 characters (lll)',
+            values: ['long/line.go', '21', :warning, 'line is 121 characters (lll)'],
+          },
+          {
+            line:   'long/line.go:21: S1000: should use for range instead of for { select {} }',
+            values: [
+              'long/line.go',
+              '21',
+              :warning,
+              'S1000: should use for range instead of for { select {} }',
+            ],
+          },
+          {
+            line:   'long/line.go:21:12: S1000: should use for range instead of for { select {} }',
+            values: [
+              'long/line.go',
+              '21',
+              :warning,
+              'S1000: should use for range instead of for { select {} }',
+            ],
+          },
+        ].each do |test_case|
+          it "parses line '#{test_case[:line]}' correctly" do
+            expect(base.parse_line(test_case[:line])).to eq(test_case[:values])
+          end
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Fixes some bugs for when the cursor position in the line is shown